### PR TITLE
Added ":text_part_charset" option for multi part mail.

### DIFF
--- a/lib/pony.rb
+++ b/lib/pony.rb
@@ -219,6 +219,10 @@ module Pony
 
     mail.charset = options[:charset] if options[:charset] # charset must be set after setting content_type
 
+    if mail.multipart? && options[:text_part_charset]
+      mail.text_part.charset = options[:text_part_charset]
+    end
+
     mail
   end
 

--- a/spec/pony_spec.rb
+++ b/spec/pony_spec.rb
@@ -82,6 +82,11 @@ describe Pony do
       mail.charset.should == 'UTF-8'
     end
 
+    it "text_part_charset" do
+      mail = Pony.build_mail(:attachments => {"foo.txt" => "content of foo.txt"}, :body => 'test', :text_part_charset => 'ISO-2022-JP')
+      mail.text_part.charset.should == 'ISO-2022-JP'
+    end
+
     it "default charset" do
       Pony.build_mail(:body => 'body').charset.should == 'UTF-8'
       Pony.build_mail(:body => 'body', :content_type => 'text/html').charset.should == 'UTF-8'


### PR DESCRIPTION
Hi, thanks for maintaining pony.

I added new option ":text_part_charset" for multi part mail.
Because current ":charset" doesn't applied to text part if it's multi part.

Please check it out.
Thank you.
