### PR TITLE
Do not require rubygems

### DIFF
--- a/lib/pony.rb
+++ b/lib/pony.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'mail'
 require 'base64'
 


### PR DESCRIPTION
Delete the rubygems require, which makes pony unusable on systems without rubygems.

For background, please see https://gist.github.com/54177.
