### PR TITLE
Update rspec to v2.14 and to use expect over should and eq over ==

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,26 @@
 PATH
   remote: .
   specs:
-    pony (1.5.1)
+    pony (1.6)
       mail (>= 2.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.2.4)
+    diff-lcs (1.2.5)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.25)
+    mime-types (1.25.1)
     polyglot (0.3.3)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.7)
+    rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
+    rspec-mocks (2.14.4)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -30,4 +30,4 @@ PLATFORMS
 
 DEPENDENCIES
   pony!
-  rspec (>= 2.0.0)
+  rspec (>= 2.14)

--- a/pony.gemspec
+++ b/pony.gemspec
@@ -18,5 +18,5 @@ EOT
   s.rdoc_options = ["--inline-source", "--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.add_runtime_dependency 'mail', '>= 2.0'
-  s.add_development_dependency "rspec", ">= 2.0.0"
+  s.add_development_dependency "rspec", ">= 2.14"
 end

--- a/spec/pony_spec.rb
+++ b/spec/pony_spec.rb
@@ -4,169 +4,169 @@ require File.dirname(__FILE__) + '/base'
 describe Pony do
 
   before(:each) do
-    Pony.stub!(:deliver)
+    Pony.stub(:deliver)
   end
 
   it "sends mail" do
-    Pony.should_receive(:deliver) do |mail|
-      mail.to.should == [ 'joe@example.com' ]
-      mail.from.should == [ 'sender@example.com' ]
-      mail.subject.should == 'hi'
-      mail.body.should == 'Hello, Joe.'
+    expect(Pony).to receive(:deliver) do |mail|
+      expect(mail.to).to eq [ 'joe@example.com' ]
+      expect(mail.from).to eq [ 'sender@example.com' ]
+      expect(mail.subject).to eq 'hi'
+      expect(mail.body).to eq 'Hello, Joe.'
     end
     Pony.mail(:to => 'joe@example.com', :from => 'sender@example.com', :subject => 'hi', :body => 'Hello, Joe.')
   end
 
   it "requires :to param" do
-    lambda { Pony.mail({}) }.should raise_error(ArgumentError)
+    expect{ Pony.mail({}) }.to raise_error(ArgumentError)
   end
 
   it "doesn't require any other param" do
-    lambda { Pony.mail(:to => 'joe@example.com') }.should_not raise_error
+    expect{ Pony.mail(:to => 'joe@example.com') }.to_not raise_error
   end
 
   describe "builds a Mail object with field:" do
     it "to" do
-      Pony.build_mail(:to => 'joe@example.com').to.should == [ 'joe@example.com' ]
+      expect(Pony.build_mail(:to => 'joe@example.com').to).to eq [ 'joe@example.com' ]
     end
 
     it "to with multiple recipients" do
-      Pony.build_mail(:to => 'joe@example.com, friedrich@example.com').to.should == [ 'joe@example.com', 'friedrich@example.com' ]
+      expect(Pony.build_mail(:to => 'joe@example.com, friedrich@example.com').to).to eq [ 'joe@example.com', 'friedrich@example.com' ]
     end
 
     it "to with multiple recipients and names" do
-      Pony.build_mail(:to => 'joe@example.com, "Friedrich Hayek" <friedrich@example.com>').to.should == [ 'joe@example.com', 'friedrich@example.com' ]
+      expect(Pony.build_mail(:to => 'joe@example.com, "Friedrich Hayek" <friedrich@example.com>').to).to eq [ 'joe@example.com', 'friedrich@example.com' ]
     end
 
     it "to with multiple recipients and names in an array" do
-      Pony.build_mail(:to => ['joe@example.com', '"Friedrich Hayek" <friedrich@example.com>']).to.should == [ 'joe@example.com', 'friedrich@example.com' ]
+      expect(Pony.build_mail(:to => ['joe@example.com', '"Friedrich Hayek" <friedrich@example.com>']).to).to eq [ 'joe@example.com', 'friedrich@example.com' ]
     end
 
     it "cc" do
-      Pony.build_mail(:cc => 'joe@example.com').cc.should == [ 'joe@example.com' ]
+      expect(Pony.build_mail(:cc => 'joe@example.com').cc).to eq [ 'joe@example.com' ]
     end
 
     it "reply_to" do
-      Pony.build_mail(:reply_to => 'joe@example.com').reply_to.should == [ 'joe@example.com' ]
+      expect(Pony.build_mail(:reply_to => 'joe@example.com').reply_to).to eq [ 'joe@example.com' ]
     end
 
     it "cc with multiple recipients" do
-      Pony.build_mail(:cc => 'joe@example.com, friedrich@example.com').cc.should == [ 'joe@example.com', 'friedrich@example.com' ]
+      expect(Pony.build_mail(:cc => 'joe@example.com, friedrich@example.com').cc).to eq [ 'joe@example.com', 'friedrich@example.com' ]
     end
 
     it "from" do
-      Pony.build_mail(:from => 'joe@example.com').from.should == [ 'joe@example.com' ]
+      expect(Pony.build_mail(:from => 'joe@example.com').from).to eq [ 'joe@example.com' ]
     end
 
     it "bcc" do
-      Pony.build_mail(:bcc => 'joe@example.com').bcc.should == [ 'joe@example.com' ]
+      expect(Pony.build_mail(:bcc => 'joe@example.com').bcc).to eq [ 'joe@example.com' ]
     end
 
     it "bcc with multiple recipients" do
-      Pony.build_mail(:bcc => 'joe@example.com, friedrich@example.com').bcc.should == [ 'joe@example.com', 'friedrich@example.com' ]
+      expect(Pony.build_mail(:bcc => 'joe@example.com, friedrich@example.com').bcc).to eq [ 'joe@example.com', 'friedrich@example.com' ]
     end
 
     it "charset" do
       mail = Pony.build_mail(:charset => 'UTF-8')
-      mail.charset.should == 'UTF-8'
+      expect(mail.charset).to eq 'UTF-8'
     end
 
     it "text_part_charset" do
       mail = Pony.build_mail(:attachments => {"foo.txt" => "content of foo.txt"}, :body => 'test', :text_part_charset => 'ISO-2022-JP')
-      mail.text_part.charset.should == 'ISO-2022-JP'
+      expect(mail.text_part.charset).to eq 'ISO-2022-JP'
     end
 
     it "default charset" do
-      Pony.build_mail(body: 'body').charset.should eq 'UTF-8'
-      Pony.build_mail(html_body: 'body').charset.should eq 'UTF-8'
+      expect(Pony.build_mail(body: 'body').charset).to eq 'UTF-8'
+      expect(Pony.build_mail(html_body: 'body').charset).to eq 'UTF-8'
     end
 
     it "from (default)" do
-      Pony.build_mail({}).from.should == [ 'pony@unknown' ]
+      expect(Pony.build_mail({}).from).to eq [ 'pony@unknown' ]
     end
 
     it "subject" do
-      Pony.build_mail(:subject => 'hello').subject.should == 'hello'
+      expect(Pony.build_mail(:subject => 'hello').subject).to eq 'hello'
     end
 
     it "body" do
-      Pony.build_mail(body: 'What do you know, Joe?').body.should
-        eq 'What do you know, Joe?'
+      expect(Pony.build_mail(body: 'What do you know, Joe?').body)
+        .to eq 'What do you know, Joe?'
     end
 
     it "html_body" do
-      Pony.build_mail(html_body: 'What do you know, Joe?').parts.first.body.should
-        eq 'What do you know, Joe?'
-      Pony.build_mail(html_body: 'What do you know, Joe?').parts.first.content_type.should
-        eq 'text/html; charset=UTF-8'
+      expect(Pony.build_mail(html_body: 'What do you know, Joe?').parts.first.body)
+        .to eq 'What do you know, Joe?'
+      expect(Pony.build_mail(html_body: 'What do you know, Joe?').parts.first.content_type)
+        .to eq 'text/html; charset=UTF-8'
     end
 
     it 'content_type' do
-      Pony.build_mail(content_type: 'multipart/related').content_type.should
-        eq 'multipart/related'
+      expect(Pony.build_mail(content_type: 'multipart/related').content_type)
+        .to eq 'multipart/related'
     end
 
     it "date" do
       now = Time.now
-      Pony.build_mail(:date => now).date.should == DateTime.parse(now.to_s)
+      expect(Pony.build_mail(:date => now).date).to eq DateTime.parse(now.to_s)
     end
 
     it "message_id" do
-      Pony.build_mail(:message_id => '<abc@def.com>').message_id.should == 'abc@def.com'
+      expect(Pony.build_mail(:message_id => '<abc@def.com>').message_id).to eq 'abc@def.com'
     end
 
     it "custom headers" do
-      Pony.build_mail(:headers => {"List-ID" => "<abc@def.com>"})['List-ID'].to_s.should == '<abc@def.com>'
+      expect(Pony.build_mail(:headers => {"List-ID" => "<abc@def.com>"})['List-ID'].to_s).to eq '<abc@def.com>'
     end
 
     it "sender" do
-      Pony.build_mail(:sender => "abc@def.com")['Sender'].to_s.should == 'abc@def.com'
+      expect(Pony.build_mail(:sender => "abc@def.com")['Sender'].to_s).to eq 'abc@def.com'
     end
 
     it "utf-8 encoded subject line" do
       mail = Pony.build_mail(:to => 'btp@foo', :subject => 'Café', :body => 'body body body')
-      mail['subject'].encoded.should =~ /^Subject: =\?UTF-8/;
+      expect(mail['subject'].encoded).to match( /^Subject: =\?UTF-8/ )
     end
 
     it "attachments" do
       mail = Pony.build_mail(:attachments => {"foo.txt" => "content of foo.txt"}, :body => 'test')
-      mail.parts.length.should == 2
-      mail.parts.first.to_s.should =~ /Content-Type: text\/plain/
-      mail.attachments.first.content_id.should == "<foo.txt@#{Socket.gethostname}>"
+      expect(mail.parts.length).to eq 2
+      expect(mail.parts.first.to_s).to match( /Content-Type: text\/plain/ )
+      expect(mail.attachments.first.content_id).to eq "<foo.txt@#{Socket.gethostname}>"
     end
 
     it "suggests mime-type" do
       mail = Pony.build_mail(:attachments => {"foo.pdf" => "content of foo.pdf"})
-      mail.parts.length.should == 1
-      mail.parts.first.to_s.should =~ /Content-Type: application\/pdf/
-      mail.parts.first.to_s.should =~ /filename=foo.pdf/
-      mail.parts.first.content_transfer_encoding.to_s.should == 'base64'
+      expect(mail.parts.length).to eq 1
+      expect(mail.parts.first.to_s).to match( /Content-Type: application\/pdf/ )
+      expect(mail.parts.first.to_s).to match( /filename=foo.pdf/ )
+      expect(mail.parts.first.content_transfer_encoding.to_s).to eq 'base64'
     end
 
     it "encodes xlsx files as base64" do
       mail = Pony.build_mail(:attachments => {"foo.xlsx" => "content of foo.xlsx"})
-      mail.parts.length.should == 1
-      mail.parts.first.to_s.should =~ /Content-Type: application\/vnd.openxmlformats-officedocument.spreadsheetml.sheet/
-      mail.parts.first.to_s.should =~ /filename=foo.xlsx/
-      mail.parts.first.content_transfer_encoding.to_s.should == 'base64'
+      expect(mail.parts.length).to eq 1
+      expect(mail.parts.first.to_s).to match( /Content-Type: application\/vnd.openxmlformats-officedocument.spreadsheetml.sheet/ )
+      expect(mail.parts.first.to_s).to match( /filename=foo.xlsx/ )
+      expect(mail.parts.first.content_transfer_encoding.to_s).to eq 'base64'
     end
 
     it "passes cc and bcc as the list of recipients" do
       mail = Pony.build_mail(:to => ['to'], :cc => ['cc'], :from => ['from'], :bcc => ['bcc'])
-      mail.destinations.should ==  ['to', 'cc', 'bcc']
+      expect(mail.destinations).to eq  ['to', 'cc', 'bcc']
     end
   end
 
   describe "transport" do
     it "transports via smtp if no sendmail binary" do
-      Pony.stub!(:sendmail_binary).and_return('/does/not/exist')
-      Pony.should_receive(:build_mail).with(hash_including(:via => :smtp))
+      Pony.stub(:sendmail_binary).and_return('/does/not/exist')
+      expect(Pony).to receive(:build_mail).with(hash_including(:via => :smtp))
       Pony.mail(:to => 'foo@bar')
     end
 
     it "defaults to sendmail if no via is specified and sendmail exists" do
-      File.stub!(:executable?).and_return(true)
-      Pony.should_receive(:build_mail).with(hash_including(:via => :sendmail))
+      File.stub(:executable?).and_return(true)
+      expect(Pony).to receive(:build_mail).with(hash_including(:via => :sendmail))
       Pony.mail(:to => 'foo@bar')
     end
 
@@ -174,12 +174,12 @@ describe Pony do
 
       it "defaults to localhost as the SMTP server" do
         mail = Pony.build_mail(:to => "foo@bar", :enable_starttls_auto => true, :via => :smtp)
-        mail.delivery_method.settings[:address].should == 'localhost'
+        expect(mail.delivery_method.settings[:address]).to eq 'localhost'
       end
 
       it "enable starttls when tls option is true" do
         mail = Pony.build_mail(:to => "foo@bar", :enable_starttls_auto => true, :via => :smtp)
-        mail.delivery_method.settings[:enable_starttls_auto].should == true
+        expect(mail.delivery_method.settings[:enable_starttls_auto]).to eq true
       end
     end
   end
@@ -187,32 +187,32 @@ describe Pony do
   describe ":via option should over-ride the default transport mechanism" do
     it "should send via sendmail if :via => sendmail" do
       mail = Pony.build_mail(:to => 'joe@example.com', :via => :sendmail)
-      mail.delivery_method.kind_of?(Mail::Sendmail).should == true
+      expect(mail.delivery_method.kind_of?(Mail::Sendmail)).to eq true
     end
 
     it "should send via smtp if :via => smtp" do
       mail = Pony.build_mail(:to => 'joe@example.com', :via => :smtp)
-      mail.delivery_method.kind_of?(Mail::SMTP).should == true
+      expect(mail.delivery_method.kind_of?(Mail::SMTP)).to eq true
     end
 
   end
 
   describe "sendmail binary location" do
     it "should default to /usr/sbin/sendmail if not in path" do
-      Pony.stub!(:'`').and_return('')
-      Pony.sendmail_binary.should == '/usr/sbin/sendmail'
+      Pony.stub(:'`').and_return('')
+      expect(Pony.sendmail_binary).to eq '/usr/sbin/sendmail'
     end
   end
 
   describe "default options" do
     it "should use default options" do
-      Pony.should_receive(:build_mail).with(hash_including(:from => 'noreply@pony'))
+      expect(Pony).to receive(:build_mail).with(hash_including(:from => 'noreply@pony'))
       Pony.options = { :from => 'noreply@pony' }
       Pony.mail(:to => 'foo@bar')
     end
 
     it "should merge default options with options" do
-      Pony.should_receive(:build_mail).with(hash_including(:from => 'override@pony'))
+      expect(Pony).to receive(:build_mail).with(hash_including(:from => 'override@pony'))
       Pony.options = { :from => 'noreply@pony' }
       Pony.mail(:from => 'override@pony', :to => "foo@bar")
     end
@@ -221,7 +221,7 @@ describe Pony do
       input = { :from => 'noreply@pony' }
       Pony.options = input
       output = Pony.options
-      output.should == input
+      expect(output).to eq input
     end
   end
 


### PR DESCRIPTION
Hi, I'd like to offer this rspec upgrade plus suggestion for changes to the RSpec syntax to use the 'expect' format.  More than just a style change, it has turned turned out that using 'expect' over 'should' is a recommended practice because of dealing with delegate/proxy objects as detailed in http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax.
As detailed in the blog post "In the future, we plan to change the defaults so that only expect is available unless you explicitly enable should. We may do this as soon as RSpec 3.0, but we want to give users plenty of time to get acquianted with it."  I've also noticed that many of the major github gems have already made the move.  It also helps the spec and the error reporting readability be more english-like.
I also took the opportunity to change the '==' operator to 'eq' as recommended in the post.
All tests pass.
