### PR TITLE
Allow options to be queried from the gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,16 @@
 PATH
   remote: .
   specs:
-    pony (1.7)
+    pony (1.8)
       mail (>= 2.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    mail (2.5.4)
-      mime-types (~> 1.16)
-      treetop (~> 1.4.8)
-    mime-types (1.25.1)
-    polyglot (0.3.3)
+    mail (2.6.1)
+      mime-types (>= 1.16, < 3)
+    mime-types (2.3)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -21,9 +19,6 @@ GEM
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
-    treetop (1.4.15)
-      polyglot
-      polyglot (>= 0.3.1)
 
 PLATFORMS
   ruby

--- a/lib/pony.rb
+++ b/lib/pony.rb
@@ -106,6 +106,8 @@ module Pony
 
   @@options = {}
 
+
+
 # Default options can be set so that they don't have to be repeated.
 #
 #   Pony.options = { :from => 'noreply@example.com', :via => :smtp, :via_options => { :host => 'smtp.yourserver.com' } }
@@ -137,6 +139,10 @@ module Pony
     deliver build_mail(options)
   end
 
+  def self.permissable_options
+    standard_options + non_standard_options
+  end
+
   private
 
   def self.deliver(mail)
@@ -147,28 +153,45 @@ module Pony
     File.executable?(sendmail_binary) ? :sendmail : :smtp
   end
 
+  def self.standard_options
+    [
+      :to,
+      :cc,
+      :bcc,
+      :from,
+      :subject,
+      :content_type,
+      :message_id,
+      :sender,
+      :reply_to,
+      :smtp_envelope_to
+    ]
+  end
+
+  def self.non_standard_options
+    [
+      :attachments,
+      :body,
+      :charset,
+      :enable_starttls_auto,
+      :headers,
+      :html_body,
+      :text_part_charset,
+      :via,
+      :via_options,
+      :body_part_header,
+      :html_body_part_header
+    ]
+  end
+
   def self.build_mail(options)
     mail = Mail.new do |m|
       options[:date] ||= Time.now
       options[:from] ||= 'pony@unknown'
       options[:via_options] ||= {}
 
-      non_standard_options = [
-        :attachments,
-        :body,
-        :charset,
-        :enable_starttls_auto,
-        :headers,
-        :html_body,
-        :text_part_charset,
-        :via,
-        :via_options,
-        :body_part_header,
-        :html_body_part_header
-      ]
-
       options.each do |k, v|
-        next if non_standard_options.include?(k)
+        next if Pony.non_standard_options.include?(k)
         m.send(k, v)
       end
 

--- a/spec/pony_spec.rb
+++ b/spec/pony_spec.rb
@@ -25,6 +25,10 @@ describe Pony do
     expect{ Pony.mail(:to => 'joe@example.com') }.to_not raise_error
   end
 
+  it 'can list its available options' do
+    expect( Pony.permissable_options ).to include(:to, :body)
+  end
+
   describe "builds a Mail object with field:" do
     it "to" do
       expect(Pony.build_mail(:to => 'joe@example.com').to).to eq [ 'joe@example.com' ]


### PR DESCRIPTION
I need to filter an options hash that I'm passing into Pony to only include options allowed by Pony.  This PR adds a method that contains a whitelist of all available standard and non-standard options.

```
Pony.permissable_options
```
