### PR TITLE
Typo: "ssmtp" -> "smtp"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ And options for Sendmail:
       }
     })
 
-If you're using ssmtp, set ```:arguments => ''```.
+If you're using smtp, set ```:arguments => ''```.
 
 ## Attachments ##
 


### PR DESCRIPTION
Just noticed it while reading the docs
