### PR TITLE
Add section about testing using Mail's TestMailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ Append the options passd into Pony.mail to the body of the email.  Useful for de
 
     Pony.append_inputs
 
+### Using Pony with Testing or Spec'ing Libraries ###
+
+As pony relies on mail to send the mails, you can also use its TestMailer in your tests.
+
+    Pony.override_options = { :via => :test }
+    Pony.mail(:to => 'foo@bar')
+    Mail::TestMailer.deliveries.length
+    => 1
+    
+For further examples see the [corresponding section of mail's readme](https://github.com/mikel/mail#using-mail-with-testing-or-specing-libraries)
+
 ## Help ##
 
 If you need help using Pony, or it looks like you've found a bug,


### PR DESCRIPTION
This PR adds the great TestMailer feature to the documentation, as its only clue are the release note of v1.2.

Maybe it also makes sense to alias `Mail::TestMailer` to `Pony::TestMailer` to let the users stay within the pony namespace.