### PR TITLE
Fix `NoMethodError` when pony is used with mail 2.7.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ https://groups.google.com/forum/#!forum/ponyrb
 *  MIKAMI Yoshiyuki  [@yoshuki](https://github.com/yoshuki)
 *  Mathieu Martin  [@webmat](https://github.com/webmat)
 *  Michael Durrant  [@durrantm](https://github.com/durrantm)
+*  Michał Kwiatkowski  [@mkwiatkowski](https://github.com/mkwiatkowski)
 *  Nami-Doc
 *  Neil Middleton  [@neilmiddleton](https://github.com/neilmiddleton)
 *  Neil Mock  [@neilmock](https://github.com/neilmock)
@@ -214,6 +215,9 @@ https://groups.google.com/forum/#!forum/ponyrb
 *  rohit  [@rohit](https://github.com/rohit)
 
 ## Changelog ##
+
+#### 1.12 ####
+* fix bug: NoMethodError when using mail 2.7.0
 
 #### 1.11 ####
 * Improved handling of mails with both text and html bodies and attachments

--- a/lib/pony.rb
+++ b/lib/pony.rb
@@ -146,7 +146,7 @@ module Pony
     if @@append_inputs
       options[:body] = "#{options[:body]}/n #{options.to_s}"
     end
-    
+
     options = @@options.merge options
     options = options.merge @@override_options
 
@@ -247,10 +247,10 @@ module Pony
 
       # If all we have is a text body, we don't need to worry about parts.
       elsif options[:body]
-        body options[:body]
+        m.body options[:body]
       end
 
-      delivery_method options[:via], options[:via_options]
+      m.delivery_method options[:via], options[:via_options]
     end
 
     (options[:headers] ||= {}).each do |key, value|


### PR DESCRIPTION
It seems mail 2.7.0 introduced a regression that breaks pony.

To reproduce run `bundle update mail` and then this little snippet will trigger the exception:

```ruby
message = {
  from: "Somebody <somebody@example.com>",
  to: "Michal <michal@trivas.pl>",
  subject: "Test",
  body: "Test body"
}
Pony.mail(message)
```

The exception is:

```
NoMethodError: undefined method `body' for Pony:Module
	from /home/mk/.rvm/gems/ruby-2.4.2/gems/pony-1.11/lib/pony.rb:250:in `block in build_mail'
	from /home/mk/.rvm/gems/ruby-2.4.2/gems/mail-2.7.0/lib/mail/message.rb:155:in `initialize'
	from /home/mk/.rvm/gems/ruby-2.4.2/gems/mail-2.7.0/lib/mail/mail.rb:51:in `new'
	from /home/mk/.rvm/gems/ruby-2.4.2/gems/mail-2.7.0/lib/mail/mail.rb:51:in `new'
	from /home/mk/.rvm/gems/ruby-2.4.2/gems/pony-1.11/lib/pony.rb:215:in `build_mail'
	from /home/mk/.rvm/gems/ruby-2.4.2/gems/pony-1.11/lib/pony.rb:166:in `mail'
	from (irb):7
```

This PR fixes the issue. I also updated the changelog. Releasing a new version to rubygems would be very appreciated. :-)