### PR TITLE
Add support for passing empty hashes as attachment

### DIFF
--- a/lib/pony.rb
+++ b/lib/pony.rb
@@ -233,7 +233,9 @@ module Pony
       # we need to explicitly define a second multipart/alternative
       # boundary to encapsulate the body-parts within the
       # multipart/mixed boundary that will be created automatically.
-      if options[:attachments] && options[:html_body] && options[:body]
+      options[:attachments] ||= {}
+
+      if options[:attachments].any? && options[:html_body] && options[:body]
         mail.part(:content_type => 'multipart/alternative') do |p|
           p.html_part = build_html_part(options)
           p.text_part = build_text_part(options)
@@ -241,7 +243,7 @@ module Pony
 
       # Otherwise if there is more than one part we still need to
       # ensure that they are all declared to be separate.
-      elsif options[:html_body] || options[:attachments]
+      elsif options[:html_body] || options[:attachments].any?
         mail.html_part = build_html_part(options) if options[:html_body]
         mail.text_part = build_text_part(options) if options[:body]
 
@@ -254,7 +256,7 @@ module Pony
         mail[key] = value
       end
 
-      add_attachments(mail, options[:attachments]) if options[:attachments]
+      add_attachments(mail, options[:attachments]) if options[:attachments].any?
 
       mail.charset = options[:charset] if options[:charset] # charset must be set after setting content_type
 

--- a/spec/pony_spec.rb
+++ b/spec/pony_spec.rb
@@ -301,6 +301,24 @@ describe Pony do
   end
 
   describe "content type" do
+    shared_examples 'a mail with only html_body and body set' do
+      it { expect(mail.parts.length).to eq 2 }
+      it { expect(mail.content_type.to_s).to include( 'multipart/alternative' ) }
+      it { expect(mail.parts[0].to_s).to include( 'Content-Type: text/html' ) }
+      it { expect(mail.parts[1].to_s).to include( 'Content-Type: text/plain' ) }
+    end
+
+    context "mail html_body and body" do
+      subject(:mail) do
+        Pony.send(:build_mail,
+                  :body => 'test',
+                  :html_body => 'What do you know, Joe?',
+                  )
+      end
+
+      it_behaves_like 'a mail with only html_body and body set'
+    end
+
     context "mail with attachments, html_body and body " do
       subject(:mail) do
         Pony.send(:build_mail,
@@ -317,6 +335,18 @@ describe Pony do
       it { expect(mail.parts[0].parts[0].to_s).to include( 'Content-Type: text/html' ) }
       it { expect(mail.parts[0].parts[1].to_s).to include( 'Content-Type: text/plain' ) }
       it { expect(mail.parts[1].to_s).to include( 'Content-Type: text/plain' ) }
+    end
+
+    context "mail html_body and body and empty attachment list" do
+      subject(:mail) do
+        Pony.send(:build_mail,
+                  :body => 'test',
+                  :html_body => 'What do you know, Joe?',
+                  :attachments => {},
+                  )
+      end
+
+      it_behaves_like 'a mail with only html_body and body set'
     end
   end
 


### PR DESCRIPTION
The following two examples are behaving different. This is surprising behaviour as it breaks the mail for (at least) Outlook. The situation may happen, when the list of attachments is generated dynamically and the special empty-case is not handled.

```
Pony.send(:build_mail,
  :body => 'test',
  :html_body => 'What do you know, Joe?',
  :attachments => nil,
)
```

```
Pony.send(:build_mail,
  :body => 'test',
  :html_body => 'What do you know, Joe?',
  :attachments => {},
)
```