### PR TITLE
Add missing dependency for Ruby > 3 versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,30 @@ PATH
   remote: .
   specs:
     pony (1.13.2)
+      base64 (> 0)
       mail (>= 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    base64 (0.2.0)
+    date (3.3.4)
     diff-lcs (1.3)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
-    mini_mime (1.0.2)
+      net-imap
+      net-pop
+      net-smtp
+    mini_mime (1.1.5)
+    net-imap (0.4.10)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.0)
+      net-protocol
     rake (13.0.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -25,6 +40,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
+    timeout (0.4.1)
 
 PLATFORMS
   ruby

--- a/pony.gemspec
+++ b/pony.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.files = ["README.md", "Rakefile", "pony.gemspec" ] + Dir.glob("{lib,spec}/**/*")
   s.rdoc_options = ["--inline-source", "--charset=UTF-8"]
   s.require_paths = ["lib"]
+  s.add_runtime_dependency "base64", "> 0"
   s.add_runtime_dependency 'mail', '>= 2.0'
   s.add_development_dependency "rspec", ">= 2.14"
   s.add_development_dependency "rake"


### PR DESCRIPTION
As of Ruby 3.4.0, `base64` is not part of stdlib and must be listed in the gemspec as a dependency.